### PR TITLE
Fix hashes not being written

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     mv $out/bin/{,.}go2nix
     cat <<EOF > $out/bin/go2nix
     #!/bin/sh
-    export PATH=${lib.makeSearchPath "bin" [ ruby go go-repo-root git mercurial bazaar subversion ]}:$PATH
+    export PATH=${lib.makeSearchPath "bin" [ ruby go go-repo-root git mercurial bazaar subversion nix-prefetch-scripts nix ]}:$PATH
     export GIT_SSL_CAINFO="${cacert}/etc/ca-bundle.crt"
     export RUBYOPT=rubygems
     export GEM_PATH=${lib.makeSearchPath ruby.gemPath (with rubyLibs; [ yajl_ruby erubis ])}


### PR DESCRIPTION
Fixes #6.

The nix-prefetch commands which are called to generate hashes were
not being found, so I added nix-prefetch-scripts to PATH. The prefetch
scripts require `nix-hash`, so I added nix to PATH as well.
